### PR TITLE
fix: cannot read a module when import * as P5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as P5 from "p5";
+import P5 from "p5";
 import Mover from "./mover";
 
 const sketch = (p5: P5) => {
@@ -10,7 +10,7 @@ const sketch = (p5: P5) => {
     canvas.parent("app");
 
     // Configuring the canvas
-    p5.background("white");
+    p5.background("black");
   };
 
   // The sketch draw method


### PR DESCRIPTION
## Description
- cannot read a module when import * as P5
- so, change it to import P5

## ScreenShots

![Screenshot 2024-07-05 at 19 09 02](https://github.com/code137-5/nature-of-code-example/assets/74766722/6130d587-8463-43c0-a0a8-903606bb791e)
